### PR TITLE
Origin/fix/bop 162

### DIFF
--- a/client/src/components/GraphDashboard/GraphDashboard.tsx
+++ b/client/src/components/GraphDashboard/GraphDashboard.tsx
@@ -42,18 +42,13 @@ const GraphDashboard: React.FC<CustomBarProps> = ({ className, style, data, lang
     },
     stroke: {
       show: true,
+      curve: 'straight',
       width: [0, 2, 2, 2, 2, 2],
     },
     xaxis: {
       categories: data.labels,
     },
     yaxis: [
-      {
-        title: {
-          text: '',
-        },
-      },
-
       {
         opposite: true,
         title: {

--- a/client/src/reducers/graph/graphSlice.ts
+++ b/client/src/reducers/graph/graphSlice.ts
@@ -68,8 +68,8 @@ export const fetchGraphData = createAsyncThunk('graphData/fetch', async () => {
     const operatingIncome = calculateOperatingIncome(card)
     const grossProfit = calculateGrossProfit(card)
 
-    const cumulataiveOridinaryIncome = calculateCumulativeOrdinaryIncome(card)
-    const grossProfitMargin = calculateGrossProfitMargin(calculateGrossProfit(card), card.sales_revenue)
+    const cumulativeOrdinaryIncome = calculateCumulativeOrdinaryIncome(card)
+    const grossProfitMargin = calculateGrossProfitMargin(grossProfit, card.sales_revenue)
     const operatingProfitMargin = calculateOperatingProfitMargin(Number(card.operating_income), card.sales_revenue)
 
     if (!aggregatedData.totalSalesByDate![date]) {
@@ -84,11 +84,12 @@ export const fetchGraphData = createAsyncThunk('graphData/fetch', async () => {
     aggregatedData.totalSalesByDate![date] += parseFloat(card.sales_revenue?.toString() || '0')
     aggregatedData.totalOperatingIncomeByDate![date] += parseFloat(operatingIncome?.toString() || '0')
     aggregatedData.totalGrossProfitByDate![date] += parseFloat(grossProfit?.toString() || '0')
-
-    aggregatedData.totalCumulativeOrdinaryIncome![date] += parseFloat(cumulataiveOridinaryIncome?.toString() || '0')
+    aggregatedData.totalCumulativeOrdinaryIncome![date] += parseFloat(cumulativeOrdinaryIncome?.toString() || '0')
     aggregatedData.totalGrossProfitMarginByDate![date] += parseFloat(grossProfitMargin?.toString() || '0')
     aggregatedData.totalOperatingProfitMarginByDate![date] += parseFloat(operatingProfitMargin?.toString() || '0')
-    aggregatedData.month.push(date)
+    if (!aggregatedData.month.includes(date)) {
+      aggregatedData.month.push(date)
+    }  
   })
   return aggregatedData
 })


### PR DESCRIPTION
# Pull Request Review Comments

## Overview
- **Purpose of the PR**:
    - [ ] ■95
Graph displays way too many details need to summarise

About the graph in the upper right corner of the dashboard
For example, when “Sales” is displayed, it looks like the capture.
The data is registered for 5 companies with 5 deals, so the graph shows 5 units from “2024/4 to 2025/3”. (12x5, 60 graphs)
Will this be collectively displayed by “year and month” in the future?

ダッシュボード右上のグラフについて
たとえば「売上」を表示するとキャプチャのようになります。
データは案件を5社分登録してあるので、グラフには「2024/4～2025/3」の単位で5個分表示されています。（12x5でグラフは60個）
ここは将来的に「年月」でまとめて表示されるようになりますか？
グラフを見ていて気になったのですが、react-apexchartsを使ってLineグラフを表示させるとデフォルトでは曲線になるようです。
options -> stroke に curve: 'straight' を入れると直線の折れ線グラフになるようです。


■ISSUE 134
不具合ではないのですが、売り上げの数値が全部プラスなのに対して、利益などがマイナスの値がある場合にApexChartのグラフ表示で左右のメモリのゼロの位置がずれる現象を確認しました。
テストプログラムで再現してみました。添付画像のようにtest2の緑のグラフがマイナスの値が入っていてtest1の青のグラフとゼロの位置がずれています。
ENGLISH
It's not a bug, but when the sales values are all positive while some profit values are negative, the zero positions of the left and right y-axes in the ApexChart graph do not align.
This issue has been reproduced in a test program.
As shown in the attached images, the green graph for test2 (with negative values) causes the zero position to misalign with the blue graph for test1.


■OTHER
色々データを入力して気が付いたのですが、グラフ表示のところで「売上」の表示をOFFにすると左の数値が非表示になりました。
ONにすると元に戻ります。入力したデータによるのかもしれませんが、とりあえず報告いたします。



