### PR TITLE
Origin/fix/bop 177

### DIFF
--- a/client/src/pages/CostOfSalesResults/CostOfSalesResultsListAndEdit.tsx
+++ b/client/src/pages/CostOfSalesResults/CostOfSalesResultsListAndEdit.tsx
@@ -410,9 +410,9 @@ const CostOfSalesResultsList: React.FC = () => {
                 handleTabsClick={handleTabsClick}
                 handleNewRegistrationClick={handleNewRegistrationClick}
                 buttonConfig={[
-                  { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                   { labelKey: 'projectSalesResultsShort', tabKey: 'projectSalesResults' },
                   { labelKey: 'employeeExpensesResultsShort', tabKey: 'employeeExpensesResults' },
+                  { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                   { labelKey: 'costOfSalesResultsShort', tabKey: 'costOfSalesResults' },
                 ]}
               />

--- a/client/src/pages/CostOfSalesResults/CostOfSalesResultsRegistration.tsx
+++ b/client/src/pages/CostOfSalesResults/CostOfSalesResultsRegistration.tsx
@@ -477,9 +477,9 @@ const CostOfSalesResultsRegistration = () => {
               handleTabsClick={handleTabsClick}
               handleListClick={handleListClick}
               buttonConfig={[
-                { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                 { labelKey: 'projectSalesResultsShort', tabKey: 'projectSalesResults' },
                 { labelKey: 'employeeExpensesResultsShort', tabKey: 'employeeExpensesResults' },
+                { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                 { labelKey: 'costOfSalesResultsShort', tabKey: 'costOfSalesResults' },
               ]}
             />

--- a/client/src/pages/EmployeeExpensesResults/EmployeeExpenseResultsList.tsx
+++ b/client/src/pages/EmployeeExpensesResults/EmployeeExpenseResultsList.tsx
@@ -239,9 +239,9 @@ const EmployeeExpensesResultsList: React.FC = () => {
                 handleTabsClick={handleTabsClick}
                 handleNewRegistrationClick={handleNewRegistrationClick}
                 buttonConfig={[
-                  { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                   { labelKey: 'projectSalesResultsShort', tabKey: 'projectSalesResults' },
                   { labelKey: 'employeeExpensesResultsShort', tabKey: 'employeeExpensesResults' },
+                  { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                   { labelKey: 'costOfSalesResultsShort', tabKey: 'costOfSalesResults' },
                 ]}
               />

--- a/client/src/pages/EmployeeExpensesResults/EmployeeExpensesResultsRegistration.tsx
+++ b/client/src/pages/EmployeeExpensesResults/EmployeeExpensesResultsRegistration.tsx
@@ -623,9 +623,9 @@ const EmployeeExpensesResultsRegistration = () => {
               handleTabsClick={handleTabsClick}
               handleListClick={handleListClick}
               buttonConfig={[
-                { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                 { labelKey: 'projectSalesResultsShort', tabKey: 'projectSalesResults' },
                 { labelKey: 'employeeExpensesResultsShort', tabKey: 'employeeExpensesResults' },
+                { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                 { labelKey: 'costOfSalesResultsShort', tabKey: 'costOfSalesResults' },
               ]}
             />

--- a/client/src/pages/ExpensesResults/ExpensesResultsListAndEdit.tsx
+++ b/client/src/pages/ExpensesResults/ExpensesResultsListAndEdit.tsx
@@ -408,9 +408,9 @@ const ExpensesResultsList: React.FC = () => {
                 handleTabsClick={handleTabsClick}
                 handleNewRegistrationClick={handleNewRegistrationClick}
                 buttonConfig={[
-                  { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                   { labelKey: 'projectSalesResultsShort', tabKey: 'projectSalesResults' },
                   { labelKey: 'employeeExpensesResultsShort', tabKey: 'employeeExpensesResults' },
+                  { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                   { labelKey: 'costOfSalesResultsShort', tabKey: 'costOfSalesResults' },
                 ]}
               />

--- a/client/src/pages/ExpensesResults/ExpensesResultsRegistration.tsx
+++ b/client/src/pages/ExpensesResults/ExpensesResultsRegistration.tsx
@@ -492,9 +492,9 @@ const ExpensesResultsRegistration = () => {
               handleTabsClick={handleTabsClick}
               handleListClick={handleListClick}
               buttonConfig={[
-                { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                 { labelKey: 'projectSalesResultsShort', tabKey: 'projectSalesResults' },
                 { labelKey: 'employeeExpensesResultsShort', tabKey: 'employeeExpensesResults' },
+                { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                 { labelKey: 'costOfSalesResultsShort', tabKey: 'costOfSalesResults' },
               ]}
             />

--- a/client/src/pages/ProjectSalesResults/ProjectSalesResultsListAndEdit.tsx
+++ b/client/src/pages/ProjectSalesResults/ProjectSalesResultsListAndEdit.tsx
@@ -45,9 +45,9 @@ const ProjectSalesResultsListAndEdit: React.FC = () => {
   const [formProjects, setFormProjects] = useState([
     {
       sales_revenue: '',
+      indirect_employee_expense: '',
       dispatch_labor_expense: '',
       employee_expense: '',
-      indirect_employee_expense: '',
       expense: '',
       operating_income: '',
       non_operating_income: '',
@@ -386,9 +386,9 @@ const ProjectSalesResultsListAndEdit: React.FC = () => {
                 handleTabsClick={handleTabsClick}
                 handleNewRegistrationClick={handleNewRegistrationClick}
                 buttonConfig={[
-                  { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                   { labelKey: 'projectSalesResultsShort', tabKey: 'projectSalesResults' },
                   { labelKey: 'employeeExpensesResultsShort', tabKey: 'employeeExpensesResults' },
+                  { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                   { labelKey: 'costOfSalesResultsShort', tabKey: 'costOfSalesResults' },
                 ]}
               />
@@ -501,6 +501,15 @@ const ProjectSalesResultsListAndEdit: React.FC = () => {
                                     <td className='projectSalesResultsList_table_body_content_vertical'>
                                       <input
                                         type='text'
+                                        name='indirect_employee_expense'
+                                        value={formatNumberWithCommas(projectSalesResults.indirect_employee_expense)}
+                                        onChange={(e) => handleChange(index, e)}
+                                        onKeyDown={handleDisableKeysOnNumberInputs}
+                                      />
+                                    </td>
+                                    <td className='projectSalesResultsList_table_body_content_vertical'>
+                                      <input
+                                        type='text'
                                         name='dispatch_labor_expense'
                                         value={formatNumberWithCommas(projectSalesResults.dispatch_labor_expense)}
                                         onChange={(e) => handleChange(index, e)}
@@ -512,15 +521,6 @@ const ProjectSalesResultsListAndEdit: React.FC = () => {
                                         type='text'
                                         name='employee_expense'
                                         value={formatNumberWithCommas(projectSalesResults.employee_expense)}
-                                        onChange={(e) => handleChange(index, e)}
-                                        onKeyDown={handleDisableKeysOnNumberInputs}
-                                      />
-                                    </td>
-                                    <td className='projectSalesResultsList_table_body_content_vertical'>
-                                      <input
-                                        type='text'
-                                        name='indirect_employee_expense'
-                                        value={formatNumberWithCommas(projectSalesResults.indirect_employee_expense)}
                                         onChange={(e) => handleChange(index, e)}
                                         onKeyDown={handleDisableKeysOnNumberInputs}
                                       />
@@ -618,13 +618,13 @@ const ProjectSalesResultsListAndEdit: React.FC = () => {
                                   {translate('saleRevenue', language)}
                                 </th>
                                 <th className='projectSalesResultsList_table_title_content_vertical has-text-centered'>
+                                  {translate('indirectEmployeeExpense', language)}
+                                </th>
+                                <th className='projectSalesResultsList_table_title_content_vertical has-text-centered'>
                                   {translate('dispatchLaborExpense', language)}
                                 </th>
                                 <th className='projectSalesResultsList_table_title_content_vertical has-text-centered'>
                                   {translate('employeeExpense', language)}
-                                </th>
-                                <th className='projectSalesResultsList_table_title_content_vertical has-text-centered'>
-                                  {translate('indirectEmployeeExpense', language)}
                                 </th>
                                 <th className='projectSalesResultsList_table_title_content_vertical has-text-centered'>
                                   {translate('expense', language)}
@@ -681,13 +681,13 @@ const ProjectSalesResultsListAndEdit: React.FC = () => {
                                     {formatNumberWithCommas(project.sales_revenue)}
                                   </td>
                                   <td className='projectSalesResultsList_table_body_content_vertical'>
+                                    {formatNumberWithCommas(project.indirect_employee_expense)}
+                                  </td>
+                                  <td className='projectSalesResultsList_table_body_content_vertical'>
                                     {formatNumberWithCommas(project.dispatch_labor_expense)}
                                   </td>
                                   <td className='projectSalesResultsList_table_body_content_vertical'>
                                     {formatNumberWithCommas(project.employee_expense)}
-                                  </td>
-                                  <td className='projectSalesResultsList_table_body_content_vertical'>
-                                    {formatNumberWithCommas(project.indirect_employee_expense)}
                                   </td>
                                   <td className='projectSalesResultsList_table_body_content_vertical'>
                                     {formatNumberWithCommas(project.expense)}

--- a/client/src/pages/ProjectSalesResults/ProjectSalesResultsRegistration.tsx
+++ b/client/src/pages/ProjectSalesResults/ProjectSalesResultsRegistration.tsx
@@ -687,9 +687,9 @@ const ProjectSalesResultsRegistration = () => {
               handleTabsClick={handleTabsClick}
               handleListClick={handleListClick}
               buttonConfig={[
-                { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                 { labelKey: 'projectSalesResultsShort', tabKey: 'projectSalesResults' },
                 { labelKey: 'employeeExpensesResultsShort', tabKey: 'employeeExpensesResults' },
+                { labelKey: 'expensesResultsShort', tabKey: 'expensesResults' },
                 { labelKey: 'costOfSalesResultsShort', tabKey: 'costOfSalesResults' },
               ]}
             />

--- a/client/src/pages/Projects/ProjectsListAndEdit.tsx
+++ b/client/src/pages/Projects/ProjectsListAndEdit.tsx
@@ -57,9 +57,9 @@ const ProjectsListAndEdit: React.FC = () => {
       client: '',
       business_division: '',
       sales_revenue: '',
+      indirect_employee_expense: '',
       dispatch_labor_expense: '',
       employee_expense: '',
-      indirect_employee_expense: '',
       expense: '',
       operating_income: '',
       non_operating_income: '',
@@ -446,13 +446,13 @@ const ProjectsListAndEdit: React.FC = () => {
                                     {translate('saleRevenue', language)}
                                   </th>
                                   <th className='projectsList-table-title-content-vertical has-text-centered'>
+                                    {translate('indirectEmployeeExpense', language)}
+                                  </th>
+                                  <th className='projectsList-table-title-content-vertical has-text-centered'>
                                     {translate('dispatchLaborExpense', language)}
                                   </th>
                                   <th className='projectsList-table-title-content-vertical has-text-centered'>
                                     {translate('employeeExpense', language)}
-                                  </th>
-                                  <th className='projectsList-table-title-content-vertical has-text-centered'>
-                                    {translate('indirectEmployeeExpense', language)}
                                   </th>
                                   <th className='projectsList-table-title-content-vertical has-text-centered'>
                                     {translate('expense', language)}
@@ -573,6 +573,15 @@ const ProjectsListAndEdit: React.FC = () => {
                                     <td className='projectsList-table-body-content-vertical'>
                                       <input
                                         type='text'
+                                        name='indirect_employee_expense'
+                                        value={formatNumberWithCommas(project.indirect_employee_expense)}
+                                        onChange={(e) => handleChange(index, e)}
+                                        onKeyDown={handleDisableKeysOnNumberInputs}
+                                      />
+                                    </td>
+                                    <td className='projectsList-table-body-content-vertical'>
+                                      <input
+                                        type='text'
                                         name='dispatch_labor_expense'
                                         value={formatNumberWithCommas(project.dispatch_labor_expense)}
                                         onChange={(e) => handleChange(index, e)}
@@ -584,15 +593,6 @@ const ProjectsListAndEdit: React.FC = () => {
                                         type='text'
                                         name='employee_expense'
                                         value={formatNumberWithCommas(project.employee_expense)}
-                                        onChange={(e) => handleChange(index, e)}
-                                        onKeyDown={handleDisableKeysOnNumberInputs}
-                                      />
-                                    </td>
-                                    <td className='projectsList-table-body-content-vertical'>
-                                      <input
-                                        type='text'
-                                        name='indirect_employee_expense'
-                                        value={formatNumberWithCommas(project.indirect_employee_expense)}
                                         onChange={(e) => handleChange(index, e)}
                                         onKeyDown={handleDisableKeysOnNumberInputs}
                                       />


### PR DESCRIPTION
# Pull Request Review Comments

## Overview
- **Purpose of the PR**:
    - [ ] 「案件」　と「案件売上実績登録画面」のラベルについて、編集モードを切り替えると位置がずれる現象がある
Labels in the ‘Forms’ and ‘Forms Sales Registration Screen’ are misaligned when switching between edit modes.

1. projects: listとeditのヘッダーの順番が違う。 edit 「画面と 」list "画面のヘッダーの順序を同じにする。
2. projects results: listとeditのヘッダーの順番が違う。 edit 「画面と 」list "画面のヘッダーの順序を同じにする。