### PR TITLE
Origin/fix/bop 178

### DIFF
--- a/client/src/pages/CostOfSales/CostOfSalesListAndEdit.tsx
+++ b/client/src/pages/CostOfSales/CostOfSalesListAndEdit.tsx
@@ -269,13 +269,44 @@ const CostOfSalesList: React.FC = () => {
   // Fixed months array
   const months = [4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3]
 
-  // Extract unique years from the costOfSales data
-  const uniqueYears = Array.from(new Set(costOfSales.map((item) => item.year))).sort((a, b) => a - b)
+  // Since it's necessary for determining the sorting order of the year and month, the types should be unified.
+  const normalizedcostOfSales = costOfSales.map((item) => ({
+    ...item,
+    month: parseInt(item.month, 10),
+    year:  parseInt(item.year,  10),
+  }));
 
-  // Combine static months with dynamic data
-  const combinedData = uniqueYears.flatMap((year) => {
-    return months.map((month) => {
-      const foundData = costOfSales.find((item) => parseInt(item.month, 10) === month && item.year === year)
+  // Calculate the fiscal year based on the access date
+  const getFiscalYearRange = (accessDate) => {
+    const currentYear  = accessDate.getFullYear();
+    const currentMonth = accessDate.getMonth() + 1;
+    const startYear = currentMonth < 4 ? currentYear - 1 : currentYear;
+    const endYear   = startYear + 1;
+
+    return {
+      startYear,
+      endYear,
+      startMonth: 4,
+      endMonth: 3,
+    };
+  };
+  
+  // Filter and combine data based on the fiscal year range
+  const getFiscalYearData = (normalizedcostOfSales, months, fiscalYearRange) => {
+    const { startYear, endYear, startMonth, endMonth } = fiscalYearRange;
+    return months.flatMap((month) => {
+      const year =
+        month >= startMonth && month <= 12
+          ? startYear
+          : month <= endMonth
+          ? endYear
+          : null;
+
+      if (!year) return [];
+
+      const foundData = normalizedcostOfSales.find(
+        (item) => item.month === month && item.year === year
+      );
 
       return {
         cost_of_sale_id: foundData ? foundData.cost_of_sale_id : null,
@@ -288,11 +319,17 @@ const CostOfSalesList: React.FC = () => {
         communication_expense: foundData ? foundData.communication_expense : '',
         work_in_progress_expense: foundData ? foundData.work_in_progress_expense : '',
         amortization_expense: foundData ? foundData.amortization_expense : '',
-      }
-    })
-  })
+      };
+    });
+  };
 
-  const validData = combinedData.filter((data) => data.cost_of_sale_id !== null)
+  // Determine the 'fiscal year' based on the system date at the time of access.
+  const accessDate      = new Date();
+  const fiscalYearRange = getFiscalYearRange(accessDate);
+  const combinedData    = getFiscalYearData(normalizedcostOfSales, months, fiscalYearRange);
+
+  // Filter valid data (only rows with an expense_id)
+  const validData = combinedData.filter((data) => data.expense_id !== null);
 
   useEffect(() => {
     setIsTranslateSwitchActive(language === 'en')

--- a/client/src/pages/CostOfSales/CostOfSalesListAndEdit.tsx
+++ b/client/src/pages/CostOfSales/CostOfSalesListAndEdit.tsx
@@ -328,8 +328,8 @@ const CostOfSalesList: React.FC = () => {
   const fiscalYearRange = getFiscalYearRange(accessDate);
   const combinedData    = getFiscalYearData(normalizedcostOfSales, months, fiscalYearRange);
 
-  // Filter valid data (only rows with an expense_id)
-  const validData = combinedData.filter((data) => data.expense_id !== null);
+  // Filter valid data (only rows with an cost_of_sale_id)
+  const validData = combinedData.filter((data) => data.cost_of_sale_id !== null);
 
   useEffect(() => {
     setIsTranslateSwitchActive(language === 'en')
@@ -494,12 +494,8 @@ const CostOfSalesList: React.FC = () => {
                         </thead>
                         <tbody className='costOfSalesList_table_body'>
                           {combinedData.map((costOfSale, index) => {
-                            const isNewYear = index === 0 || combinedData[index - 1].year !== costOfSale.year
-                            const isLastcostOfSaleOfYear =
-                              index !== combinedData.length - 1 && combinedData[index + 1].year !== costOfSale.year
-
+                            const isLastExpenseOfYear = costOfSale.month === 3;
                             const isEditable = costOfSale.cost_of_sale_id !== null
-
                             return (
                               <React.Fragment key={index}>
                                 {costOfSale ? (
@@ -591,7 +587,7 @@ const CostOfSalesList: React.FC = () => {
                                     </td>
                                   </tr>
                                 ) : null}
-                                {isLastcostOfSaleOfYear && (
+                                {isLastExpenseOfYear && (
                                   <tr className='year-separator'>
                                     <td className='horizontal-line-cell' colSpan={9}>
                                       <div className='horizontal-line' />
@@ -639,10 +635,7 @@ const CostOfSalesList: React.FC = () => {
                       </thead>
                       <tbody className='costOfSalesList_table_body'>
                         {combinedData.map((costOfSale, index) => {
-                          const isNewYear = index === 0 || combinedData[index - 1].year !== costOfSale.year
-                          const isLastcostOfSaleOfYear =
-                            index !== combinedData.length - 1 && combinedData[index + 1].year !== costOfSale.year
-
+                          const isLastExpenseOfYear = costOfSale.month === 3;
                           return (
                             <React.Fragment key={index}>
                               <tr className='costOfSalesList_table_body_content_horizontal'>
@@ -674,7 +667,7 @@ const CostOfSalesList: React.FC = () => {
                                   {formatNumberWithCommas(costOfSale.amortization_expense) || 0}
                                 </td>
                               </tr>
-                              {isLastcostOfSaleOfYear && (
+                              {isLastExpenseOfYear && (
                                 <tr className='year-separator'>
                                   <td className='horizontal-line-cell' colSpan={9}>
                                     <div className='horizontal-line' />

--- a/client/src/pages/CostOfSales/CostOfSalesRegistration.tsx
+++ b/client/src/pages/CostOfSales/CostOfSalesRegistration.tsx
@@ -142,21 +142,7 @@ const CostOfSalesRegistration = () => {
   }
 
 
-const handleChange = (index, event) => {
-  const { name, value } = event.target
 
-  // Remove commas to get the raw number
-  // EG. 999,999 → 999999 in the DB
-  const rawValue = removeCommas(value)
-
-  // Update the state with the raw value
-  const newFormData = [...formData]
-  newFormData[index] = {
-    ...newFormData[index],
-    [name]: rawValue, // Store unformatted value in the state
-  }
-  setFormData(newFormData)
-}
 
   
   useEffect(() => {
@@ -314,6 +300,35 @@ const handleChange = (index, event) => {
     }
   }
 
+  const currentDate = new Date();
+  const currentYear = currentDate.getFullYear();
+  const currentFiscalYear = currentDate.getMonth() + 1 < 4 ? currentYear - 1 : currentYear;
+  const [months, setMonths] = useState<number[]>([]);
+  const handleChange = (index, event) => {
+    const { name, value } = event.target
+
+    // Remove commas to get the raw number
+    // EG. 999,999 → 999999 in the DB
+    const rawValue = removeCommas(value)
+
+    const updatedFormData = [...formData]
+    updatedFormData[index] = {
+      ...updatedFormData[index],
+      [name]: rawValue,
+    }
+    setFormData(updatedFormData)
+
+    if (name === 'year') {
+      const selectedYear = parseInt(rawValue, 10);
+      if (selectedYear === currentFiscalYear) {
+        setMonths([4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      } else if (selectedYear === (currentFiscalYear + 1)) {
+        setMonths([1, 2, 3]);
+      } else {
+        setMonths([]);
+      }
+    }
+  }
   useEffect(() => {}, [formData])
 
   useEffect(() => {

--- a/client/src/pages/CostOfSalesResults/CostOfSalesResultsListAndEdit.tsx
+++ b/client/src/pages/CostOfSalesResults/CostOfSalesResultsListAndEdit.tsx
@@ -267,13 +267,44 @@ const CostOfSalesResultsList: React.FC = () => {
   // Fixed months array
   const months = [4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3]
 
-  // Extract unique years from the costOfSales data
-  const uniqueYears = Array.from(new Set(costOfSalesResults.map((item) => item.year))).sort((a, b) => a - b)
+  // Since it's necessary for determining the sorting order of the year and month, the types should be unified.
+  const normalizedCostOfSalesResults = costOfSalesResults.map((item) => ({
+    ...item,
+    month: parseInt(item.month, 10),
+    year:  parseInt(item.year,  10),
+  }));
 
-  // Combine static months with dynamic data
-  const combinedData = uniqueYears.flatMap((year) => {
-    return months.map((month) => {
-      const foundData = costOfSalesResults.find((item) => parseInt(item.month, 10) === month && item.year === year)
+  // Calculate the fiscal year based on the access date
+  const getFiscalYearRange = (accessDate) => {
+    const currentYear  = accessDate.getFullYear();
+    const currentMonth = accessDate.getMonth() + 1;
+    const startYear = currentMonth < 4 ? currentYear - 1 : currentYear;
+    const endYear   = startYear + 1;
+
+    return {
+      startYear,
+      endYear,
+      startMonth: 4,
+      endMonth: 3,
+    };
+  };
+  
+  // Filter and combine data based on the fiscal year range
+  const getFiscalYearData = (normalizedCostOfSalesResults, months, fiscalYearRange) => {
+    const { startYear, endYear, startMonth, endMonth } = fiscalYearRange;
+    return months.flatMap((month) => {
+      const year =
+        month >= startMonth && month <= 12
+          ? startYear
+          : month <= endMonth
+          ? endYear
+          : null;
+
+      if (!year) return [];
+
+      const foundData = normalizedCostOfSalesResults.find(
+        (item) => item.month === month && item.year === year
+      );
 
       return {
         cost_of_sale_result_id: foundData ? foundData.cost_of_sale_result_id : null,
@@ -286,10 +317,17 @@ const CostOfSalesResultsList: React.FC = () => {
         communication_expense: foundData ? foundData.communication_expense : '',
         work_in_progress_expense: foundData ? foundData.work_in_progress_expense : '',
         amortization_expense: foundData ? foundData.amortization_expense : '',
-      }
-    })
-  })
-  const validData = combinedData.filter((data) => data.cost_of_sale_result_id !== null)
+      };
+    });
+  };
+
+  // Determine the 'fiscal year' based on the system date at the time of access.
+  const accessDate      = new Date();
+  const fiscalYearRange = getFiscalYearRange(accessDate);
+  const combinedData    = getFiscalYearData(normalizedCostOfSalesResults, months, fiscalYearRange);
+
+  // Filter valid data (only rows with an expense_id)
+  const validData = combinedData.filter((data) => data.expense_id !== null);
 
   useEffect(() => {
     setIsTranslateSwitchActive(language === 'en')
@@ -456,7 +494,7 @@ const CostOfSalesResultsList: React.FC = () => {
                           </tr>
                         </thead>
                         <tbody className='costOfSalesResultsList_table_body'>
-                          {combinedData.map((costOfSale, index) => {
+                          {validData.map((costOfSale, index) => {
                             const isNewYear = index === 0 || combinedData[index - 1].year !== costOfSale.year
                             const isLastcostOfSaleOfYear =
                               index !== combinedData.length - 1 && combinedData[index + 1].year !== costOfSale.year

--- a/client/src/pages/CostOfSalesResults/CostOfSalesResultsListAndEdit.tsx
+++ b/client/src/pages/CostOfSalesResults/CostOfSalesResultsListAndEdit.tsx
@@ -495,7 +495,7 @@ const CostOfSalesResultsList: React.FC = () => {
                         </thead>
                         <tbody className='costOfSalesResultsList_table_body'>
                           {combinedData.map((costOfSale, index) => {
-                            const isLastExpenseOfYear = costOfSale.month === 3;
+                            const isLastCostOfSaleOfYear = costOfSale.month === 3;
                             const isEditable = costOfSale.cost_of_sale_result_id !== null
 
                             return (
@@ -591,7 +591,7 @@ const CostOfSalesResultsList: React.FC = () => {
                                     </td>
                                   </tr>
                                 ) : null}
-                                {isLastExpenseOfYear && (
+                                {isLastCostOfSaleOfYear && (
                                   <tr className='year-separator'>
                                     <td className='horizontal-line-cell' colSpan={9}>
                                       <div className='horizontal-line' />
@@ -639,7 +639,7 @@ const CostOfSalesResultsList: React.FC = () => {
                       </thead>
                       <tbody className='costOfSalesResultsList_table_body'>
                         {combinedData.map((costOfSale, index) => {
-                          const isLastExpenseOfYear = costOfSale.month === 3;
+                          const isLastCostOfSaleOfYear = costOfSale.month === 3;
                           return (
                             <React.Fragment key={index}>
                               <tr className='costOfSalesResultsList_table_body_content_horizontal'>
@@ -671,7 +671,7 @@ const CostOfSalesResultsList: React.FC = () => {
                                   {formatNumberWithCommas(costOfSale.amortization_expense) || 0}
                                 </td>
                               </tr>
-                              {isLastExpenseOfYear && (
+                              {isLastCostOfSaleOfYear && (
                                 <tr className='year-separator'>
                                   <td className='horizontal-line-cell' colSpan={9}>
                                     <div className='horizontal-line' />

--- a/client/src/pages/CostOfSalesResults/CostOfSalesResultsListAndEdit.tsx
+++ b/client/src/pages/CostOfSalesResults/CostOfSalesResultsListAndEdit.tsx
@@ -326,8 +326,8 @@ const CostOfSalesResultsList: React.FC = () => {
   const fiscalYearRange = getFiscalYearRange(accessDate);
   const combinedData    = getFiscalYearData(normalizedCostOfSalesResults, months, fiscalYearRange);
 
-  // Filter valid data (only rows with an expense_id)
-  const validData = combinedData.filter((data) => data.expense_id !== null);
+  // Filter valid data (only rows with an cost_of_sale_result_id)
+  const validData = combinedData.filter((data) => data.cost_of_sale_result_id !== null);
 
   useEffect(() => {
     setIsTranslateSwitchActive(language === 'en')
@@ -494,11 +494,8 @@ const CostOfSalesResultsList: React.FC = () => {
                           </tr>
                         </thead>
                         <tbody className='costOfSalesResultsList_table_body'>
-                          {validData.map((costOfSale, index) => {
-                            const isNewYear = index === 0 || combinedData[index - 1].year !== costOfSale.year
-                            const isLastcostOfSaleOfYear =
-                              index !== combinedData.length - 1 && combinedData[index + 1].year !== costOfSale.year
-
+                          {combinedData.map((costOfSale, index) => {
+                            const isLastExpenseOfYear = costOfSale.month === 3;
                             const isEditable = costOfSale.cost_of_sale_result_id !== null
 
                             return (
@@ -594,7 +591,7 @@ const CostOfSalesResultsList: React.FC = () => {
                                     </td>
                                   </tr>
                                 ) : null}
-                                {isLastcostOfSaleOfYear && (
+                                {isLastExpenseOfYear && (
                                   <tr className='year-separator'>
                                     <td className='horizontal-line-cell' colSpan={9}>
                                       <div className='horizontal-line' />
@@ -642,10 +639,7 @@ const CostOfSalesResultsList: React.FC = () => {
                       </thead>
                       <tbody className='costOfSalesResultsList_table_body'>
                         {combinedData.map((costOfSale, index) => {
-                          const isNewYear = index === 0 || combinedData[index - 1].year !== costOfSale.year
-                          const isLastcostOfSaleOfYear =
-                            index !== combinedData.length - 1 && combinedData[index + 1].year !== costOfSale.year
-
+                          const isLastExpenseOfYear = costOfSale.month === 3;
                           return (
                             <React.Fragment key={index}>
                               <tr className='costOfSalesResultsList_table_body_content_horizontal'>
@@ -677,7 +671,7 @@ const CostOfSalesResultsList: React.FC = () => {
                                   {formatNumberWithCommas(costOfSale.amortization_expense) || 0}
                                 </td>
                               </tr>
-                              {isLastcostOfSaleOfYear && (
+                              {isLastExpenseOfYear && (
                                 <tr className='year-separator'>
                                   <td className='horizontal-line-cell' colSpan={9}>
                                     <div className='horizontal-line' />

--- a/client/src/pages/Expenses/ExpensesListAndEdit.tsx
+++ b/client/src/pages/Expenses/ExpensesListAndEdit.tsx
@@ -306,33 +306,35 @@ const ExpensesList: React.FC = () => {
   }, [location.pathname])
 
   // Extract unique years from the expenses data
-  const uniqueYears = Array.from(new Set(expensesList.map((item) => item.year))).sort((a, b) => a - b)
 
   // Combine static months with dynamic data
-  const combinedData = uniqueYears.flatMap((year) => {
-    return months.map((month) => {
-      const foundData = expensesList.find((item) => parseInt(item.month, 10) === month && item.year === year)
 
-      return {
-        expense_id: foundData ? foundData.expense_id : null,
-        month,
-        year,
-        consumable_expense: foundData ? foundData.consumable_expense : '',
-        rent_expense: foundData ? foundData.rent_expense : '',
-        tax_and_public_charge: foundData ? foundData.tax_and_public_charge : '',
-        depreciation_expense: foundData ? foundData.depreciation_expense : '',
-        travel_expense: foundData ? foundData.travel_expense : '',
-        communication_expense: foundData ? foundData.communication_expense : '',
-        utilities_expense: foundData ? foundData.utilities_expense : '',
-        transaction_fee: foundData ? foundData.transaction_fee : '',
-        advertising_expense: foundData ? foundData.advertising_expense : '',
-        entertainment_expense: foundData ? foundData.entertainment_expense : '',
-        professional_service_fee: foundData ? foundData.professional_service_fee : '',
-      }
-    })
-  })
+  const combinedData = expensesList.map((item) => {
+    return {
+      expense_id: item.expense_id,
+      month: parseInt(item.month, 10), // 数値に変換
+      year: item.year,
+      consumable_expense: item.consumable_expense || '',
+      rent_expense: item.rent_expense || '',
+      tax_and_public_charge: item.tax_and_public_charge || '',
+      depreciation_expense: item.depreciation_expense || '',
+      travel_expense: item.travel_expense || '',
+      communication_expense: item.communication_expense || '',
+      utilities_expense: item.utilities_expense || '',
+      transaction_fee: item.transaction_fee || '',
+      advertising_expense: item.advertising_expense || '',
+      entertainment_expense: item.entertainment_expense || '',
+      professional_service_fee: item.professional_service_fee || '',
+    };
+  });
 
-  const validData = combinedData.filter((data) => data.expense_id !== null)
+  // Sort data by year and month
+  const validData = combinedData.sort((a, b) => {
+    if (a.year === b.year) {
+      return a.month - b.month; // 月で昇順にソート
+    }
+    return a.year - b.year; // 年で昇順にソート
+  });
 
   useEffect(() => {
     setIsTranslateSwitchActive(language === 'en')
@@ -496,10 +498,10 @@ const ExpensesList: React.FC = () => {
                           </tr>
                         </thead>
                         <tbody className='expensesList_table_body'>
-                          {combinedData.map((expense, index) => {
-                            const isNewYear = index === 0 || combinedData[index - 1].year !== expense.year
+                        {validData.map((expense, index) => {
+                            const isNewYear = index === 0 || validData[index - 1].year !== expense.year;
                             const isLastExpenseOfYear =
-                              index !== combinedData.length - 1 && combinedData[index + 1].year !== expense.year
+                              index !== validData.length - 1 && validData[index + 1].year !== expense.year;
 
                             const isEditable = expense.expense_id !== null
 

--- a/client/src/pages/Expenses/ExpensesListAndEdit.tsx
+++ b/client/src/pages/Expenses/ExpensesListAndEdit.tsx
@@ -535,13 +535,9 @@ const ExpensesList: React.FC = () => {
                           </tr>
                         </thead>
                         <tbody className='expensesList_table_body'>
-                        {validData.map((expense, index) => {
-                            const isNewYear = index === 0 || validData[index - 1].year !== expense.year;
-                            const isLastExpenseOfYear =
-                              index !== validData.length - 1 && validData[index + 1].year !== expense.year;
-
+                        {combinedData.map((expense, index) => {
+                            const isLastExpenseOfYear = expense.month === 3;
                             const isEditable = expense.expense_id !== null
-
                             return (
                               <React.Fragment key={index}>
                                 {expense ? (
@@ -700,10 +696,7 @@ const ExpensesList: React.FC = () => {
                       </thead>
                       <tbody className='expensesList_table_body'>
                         {combinedData.map((expense, index) => {
-                          const isNewYear = index === 0 || combinedData[index - 1].year !== expense.year
-                          const isLastExpenseOfYear =
-                            index !== combinedData.length - 1 && combinedData[index + 1].year !== expense.year
-
+                          const isLastExpenseOfYear = expense.month === 3;
                           return (
                             <React.Fragment key={index}>
                               <tr className='expensesList_table_body_content_horizontal'>

--- a/client/src/pages/Expenses/ExpensesRegistration.tsx
+++ b/client/src/pages/Expenses/ExpensesRegistration.tsx
@@ -60,23 +60,6 @@ const ExpensesRegistration = () => {
     setLanguage(newLanguage)
   }
 
-const handleChange = (index, event) => {
-  const { name, value } = event.target
-
-  // Remove commas to get the raw number
-  // EG. 999,999 → 999999 in the DB
-  const rawValue = removeCommas(value)
-
-  // Update form data
-  const newFormData = [...formData]
-  newFormData[index] = {
-    ...newFormData[index],
-    [name]: rawValue,
-  }
-
-  setFormData(newFormData)
-}
-
   const maximumEntries = 10;
 
   const handleAdd = () => {
@@ -112,6 +95,36 @@ const handleChange = (index, event) => {
     }
   }
 
+  const currentDate = new Date();
+  const currentYear = currentDate.getFullYear();
+  const currentFiscalYear = currentDate.getMonth() + 1 < 4 ? currentYear - 1 : currentYear;
+  const [months, setMonths] = useState<number[]>([]);
+  const handleChange = (index, event) => {
+    const { name, value } = event.target
+
+    // Remove commas to get the raw number
+    // EG. 999,999 → 999999 in the DB
+    const rawValue = removeCommas(value)
+
+    const updatedFormData = [...formData]
+    updatedFormData[index] = {
+      ...updatedFormData[index],
+      [name]: rawValue,
+    }
+    setFormData(updatedFormData)
+
+    if (name === 'year') {
+      const selectedYear = parseInt(rawValue, 10);
+      if (selectedYear === currentFiscalYear) {
+        setMonths([4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      } else if (selectedYear === (currentFiscalYear + 1)) {
+        setMonths([1, 2, 3]);
+      } else {
+        setMonths([]);
+      }
+    }
+  }
+  useEffect(() => {}, [formData])
   useEffect(() => {
     const path = location.pathname
     if (path === '/dashboard' || path === '/planning-list' || path === '/*') {

--- a/client/src/pages/ExpensesResults/ExpensesResultsListAndEdit.tsx
+++ b/client/src/pages/ExpensesResults/ExpensesResultsListAndEdit.tsx
@@ -339,8 +339,8 @@ const ExpensesResultsList: React.FC = () => {
   const fiscalYearRange = getFiscalYearRange(accessDate);
   const combinedData    = getFiscalYearData(normalizedExpensesResultsList, months, fiscalYearRange);
 
-  // Filter valid data (only rows with an expense_id)
-  const validData = combinedData.filter((data) => data.expense_id !== null);
+  // Filter valid data (only rows with an expense_result_id)
+  const validData = combinedData.filter((data) => data.expense_result_id !== null);
 
   useEffect(() => {
     setIsTranslateSwitchActive(language === 'en')
@@ -504,13 +504,9 @@ const ExpensesResultsList: React.FC = () => {
                           </tr>
                         </thead>
                         <tbody className='expensesResultsList_table_body'>
-                          {validData.map((expenseResults, index) => {
-                            const isNewYear = index === 0 || combinedData[index - 1].year !== expenseResults.year
-                            const isLastExpenseOfYear =
-                              index !== combinedData.length - 1 && combinedData[index + 1].year !== expenseResults.year
-
+                          {combinedData.map((expenseResults, index) => {
+                            const isLastExpenseOfYear = expenseResults.month === 3;
                             const isEditable = expenseResults.expense_result_id !== null
-
                             return (
                               <React.Fragment key={index}>
                                 {expenseResults ? (
@@ -672,10 +668,7 @@ const ExpensesResultsList: React.FC = () => {
                       </thead>
                       <tbody className='expensesResultsList_table_body'>
                         {combinedData.map((expenseResults, index) => {
-                          const isNewYear = index === 0 || combinedData[index - 1].year !== expenseResults.year
-                          const isLastExpenseOfYear =
-                            index !== combinedData.length - 1 && combinedData[index + 1].year !== expenseResults.year
-
+                          const isLastExpenseOfYear = expenseResults.month === 3;
                           return (
                             <React.Fragment key={index}>
                               <tr className='expensesResultsList_table_body_content_horizontal'>

--- a/client/src/pages/ExpensesResults/ExpensesResultsListAndEdit.tsx
+++ b/client/src/pages/ExpensesResults/ExpensesResultsListAndEdit.tsx
@@ -276,13 +276,44 @@ const ExpensesResultsList: React.FC = () => {
     }
   }, [location.pathname])
 
-  // Extract unique years from the expenses data
-  const uniqueYears = Array.from(new Set(expensesResultsList.map((item) => item.year))).sort((a, b) => a - b)
+  // Since it's necessary for determining the sorting order of the year and month, the types should be unified.
+  const normalizedExpensesResultsList = expensesResultsList.map((item) => ({
+    ...item,
+    month: parseInt(item.month, 10),
+    year:  parseInt(item.year,  10),
+  }));
 
-  // Combine static months with dynamic data
-  const combinedData = uniqueYears.flatMap((year) => {
-    return months.map((month) => {
-      const foundData = expensesResultsList.find((item) => parseInt(item.month, 10) === month && item.year === year)
+  // Calculate the fiscal year based on the access date
+  const getFiscalYearRange = (accessDate) => {
+    const currentYear  = accessDate.getFullYear();
+    const currentMonth = accessDate.getMonth() + 1;
+    const startYear = currentMonth < 4 ? currentYear - 1 : currentYear;
+    const endYear   = startYear + 1;
+
+    return {
+      startYear,
+      endYear,
+      startMonth: 4,
+      endMonth: 3,
+    };
+  };
+  
+  // Filter and combine data based on the fiscal year range
+  const getFiscalYearData = (normalizedExpensesResultsList, months, fiscalYearRange) => {
+    const { startYear, endYear, startMonth, endMonth } = fiscalYearRange;
+    return months.flatMap((month) => {
+      const year =
+        month >= startMonth && month <= 12
+          ? startYear
+          : month <= endMonth
+          ? endYear
+          : null;
+
+      if (!year) return [];
+
+      const foundData = normalizedExpensesResultsList.find(
+        (item) => item.month === month && item.year === year
+      );
 
       return {
         expense_result_id: foundData ? foundData.expense_result_id : null,
@@ -299,11 +330,17 @@ const ExpensesResultsList: React.FC = () => {
         advertising_expense: foundData ? foundData.advertising_expense : '',
         entertainment_expense: foundData ? foundData.entertainment_expense : '',
         professional_service_fee: foundData ? foundData.professional_service_fee : '',
-      }
-    })
-  })
+      };
+    });
+  };
 
-  const validData = combinedData.filter((data) => data.expense_result_id !== null)
+  // Determine the 'fiscal year' based on the system date at the time of access.
+  const accessDate      = new Date();
+  const fiscalYearRange = getFiscalYearRange(accessDate);
+  const combinedData    = getFiscalYearData(normalizedExpensesResultsList, months, fiscalYearRange);
+
+  // Filter valid data (only rows with an expense_id)
+  const validData = combinedData.filter((data) => data.expense_id !== null);
 
   useEffect(() => {
     setIsTranslateSwitchActive(language === 'en')
@@ -467,7 +504,7 @@ const ExpensesResultsList: React.FC = () => {
                           </tr>
                         </thead>
                         <tbody className='expensesResultsList_table_body'>
-                          {combinedData.map((expenseResults, index) => {
+                          {validData.map((expenseResults, index) => {
                             const isNewYear = index === 0 || combinedData[index - 1].year !== expenseResults.year
                             const isLastExpenseOfYear =
                               index !== combinedData.length - 1 && combinedData[index + 1].year !== expenseResults.year

--- a/client/src/pages/Projects/ProjectsRegistration.tsx
+++ b/client/src/pages/Projects/ProjectsRegistration.tsx
@@ -177,7 +177,9 @@ const ProjectsRegistration = () => {
     }
   }
 
-  const currentYear = new Date().getFullYear();
+  const currentDate = new Date();
+  const currentYear = currentDate.getFullYear();
+  const currentFiscalYear = currentDate.getMonth() + 1 < 4 ? currentYear - 1 : currentYear;
   const [months, setMonths] = useState<number[]>([]);
   const handleChange = (index, event) => {
     const { name, value } = event.target
@@ -195,9 +197,9 @@ const ProjectsRegistration = () => {
 
     if (name === 'year') {
       const selectedYear = parseInt(rawValue, 10);
-      if (selectedYear === currentYear) {
+      if (selectedYear === currentFiscalYear) {
         setMonths([4, 5, 6, 7, 8, 9, 10, 11, 12]);
-      } else if (selectedYear === (currentYear + 1)) {
+      } else if (selectedYear === (currentFiscalYear + 1)) {
         setMonths([1, 2, 3]);
       } else {
         setMonths([]);


### PR DESCRIPTION
# Pull Request Review Comments

## Overview
- **Purpose of the PR**:
    - [ ] 
1
English:

The code that uses new Date().getFullYear(); no longer displays month pulldown correctly.
The App is currently being designed to use 1 year at the moment. (2024 - 2025)
So months should be:　

日本語：
new Date().getFullYear(); を使用しているコードが、現在正しく月のプルダウンを表示しなくなっています。
アプリは現在、1年間（2024年～2025年）のみを使用するように設計されています。
だから数カ月はそうあるべきだ：


2
The [year] and [month] dropdowns in the following screens also need to be addressed:
以下の画面の[年]と[月]のドロップダウンにも対処する必要がある：

expenses
cost of sales



3
The current expenses and cost of sales list screens do not display the data correctly.
現在の経費と売上原価の一覧画面にデータが正しく表示されない。

One year block should be:
1年ブロックであるべきだ：

block 1
2024 → 4,5,6,7,8,9,10,11,12
2025 → 1,2,3

block 2
2025 → 4,5,6,7,8,9,10,11,12
2026 → 1,2,3

But in the screenshot below you can see it is
しかし、下のスクリーンショットを見れば、それがわかる。

block 1
2024 → 4,5,6,7,8,9,10,11,12
2024 → 1,2,3

block 2
2025 → 4,5,6,7,8,9,10,11,12
2025 → 1,2,3


