### PR TITLE
Origin/fix/bop 180

### DIFF
--- a/client/src/translations/screenNames_words_jp.json
+++ b/client/src/translations/screenNames_words_jp.json
@@ -24,7 +24,7 @@
   "costOfSalesRegistration": "売上原価登録",
   "costOfSalesList": "売上原価一覧",
   "costOfSalesEdit": "売上原価編集",
-  "costOfSalesResultsRegistration": "売上原価結果登録",
+  "costOfSalesResultsRegistration": "売上原価実績登録",
   "costOfSalesResultsList": "売上原価実績一覧",
   "costOfSalesResultsEdit": "売上原価実績編集",
   "clientsRegistration": "顧客登録",


### PR DESCRIPTION
# Pull Request Review Comments

## Overview
- **Purpose of the PR**:
    - [ ] 
English:
Fix the name for cost of sales results registration in Japanese. 売上原価結果登録 (結果　→ 実績）
日本語:
売上原価結果登録 の名称を修正。売上原価結果登録 (結果　→ 実績）