### PR TITLE
Origin/fix/bop 189

### DIFF
--- a/client/src/pages/CostOfSales/CostOfSalesListAndEdit.tsx
+++ b/client/src/pages/CostOfSales/CostOfSalesListAndEdit.tsx
@@ -494,7 +494,7 @@ const CostOfSalesList: React.FC = () => {
                         </thead>
                         <tbody className='costOfSalesList_table_body'>
                           {combinedData.map((costOfSale, index) => {
-                            const isLastExpenseOfYear = costOfSale.month === 3;
+                            const isLastCostOfSaleOfYear = costOfSale.month === 3;
                             const isEditable = costOfSale.cost_of_sale_id !== null
                             return (
                               <React.Fragment key={index}>
@@ -587,7 +587,7 @@ const CostOfSalesList: React.FC = () => {
                                     </td>
                                   </tr>
                                 ) : null}
-                                {isLastExpenseOfYear && (
+                                {isLastCostOfSaleOfYear && (
                                   <tr className='year-separator'>
                                     <td className='horizontal-line-cell' colSpan={9}>
                                       <div className='horizontal-line' />
@@ -635,7 +635,7 @@ const CostOfSalesList: React.FC = () => {
                       </thead>
                       <tbody className='costOfSalesList_table_body'>
                         {combinedData.map((costOfSale, index) => {
-                          const isLastExpenseOfYear = costOfSale.month === 3;
+                          const isLastCostOfSaleOfYear = costOfSale.month === 3;
                           return (
                             <React.Fragment key={index}>
                               <tr className='costOfSalesList_table_body_content_horizontal'>
@@ -667,7 +667,7 @@ const CostOfSalesList: React.FC = () => {
                                   {formatNumberWithCommas(costOfSale.amortization_expense) || 0}
                                 </td>
                               </tr>
-                              {isLastExpenseOfYear && (
+                              {isLastCostOfSaleOfYear && (
                                 <tr className='year-separator'>
                                   <td className='horizontal-line-cell' colSpan={9}>
                                     <div className='horizontal-line' />


### PR DESCRIPTION
# Pull Request Review Comments

## Overview
- **Purpose of the PR**:
    - [x] The costOfSales still has some misnamed items.
Same fix as costOfSales results screens.

「costOfSales」にはまだ名前が間違っている項目があります。
「costOfSales実績画面」と同様の修正が必要です。