### PR TITLE
Origin/fix/bop 198v2

### DIFF
--- a/client/src/pages/ProjectSalesResults/ProjectSalesResultsRegistration.tsx
+++ b/client/src/pages/ProjectSalesResults/ProjectSalesResultsRegistration.tsx
@@ -15,7 +15,7 @@ import { overwriteProject } from '../../api/ProjectsEndpoint/OverwriteProject'
 import { getFilteredProjectSalesResults } from '../../api/ProjectSalesResultsEndpoint/FilteredGetProjectSalesResults'
 import { createProjectSalesResults } from '../../api/ProjectSalesResultsEndpoint/CreateProjectSalesResults'
 import { overwriteProjectSalesResult } from '../../api/ProjectSalesResultsEndpoint/OverwriteProjectSalesResults'
-import { getProjectSalesResults } from '../../api/ProjectSalesResultsEndpoint/GetProjectSalesResults'
+import { getProject } from '../../api/ProjectsEndpoint/GetProject'
 import { maximumEntries, monthNames, months, resultsScreenTabs, token, years } from '../../constants'
 import { addFormInput, closeModal, openModal } from '../../actions/hooks'
 import {
@@ -28,6 +28,8 @@ import {
   handleDisableKeysOnNumberInputs,
   formatNumberWithCommas,
   removeCommas,
+  sortByFinancialYear,
+  handleGeneralResultsInputChange,
   handleResultsRegTabsClick,
 } from '../../utils/helperFunctionsUtil'
 import { MAX_NUMBER_LENGTH } from '../../constants'
@@ -59,7 +61,10 @@ type Division = {
   business_division_id: string
   business_division_name: string
 }
-
+type FilterParams = {
+  month?: string
+  year?: string
+}
 const ProjectSalesResultsRegistration = () => {
   const [activeTab, setActiveTab] = useState('/results')
   const navigate = useNavigate()
@@ -71,6 +76,8 @@ const ProjectSalesResultsRegistration = () => {
   const [selectedClient, setSelectedClient] = useState([])
   const [businessSelection, setBusinessSelection] = useState<any>([])
   const [businessDivisionFilter, setBusinessDivisionFilter] = useState<Divisions[]>([{ divisions: [] }])
+  const [filteredMonth, setFilteredMonth] = useState<any>([{ month: [] }])
+  const [ProjectYear, setProjectYear] = useState<any>([])
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const [projectDataResult, setProjectDataResult] = useState<any>([])
   const [projectList, setProjectsList] = useState<Projects[]>([{ projects: [] }])
@@ -105,12 +112,19 @@ const ProjectSalesResultsRegistration = () => {
   }
 
   const [formProjects, setProjects] = useState([emptyFormData])
-  const handleAdd = () => {
+  const uniqueYears = ProjectYear.reduce((acc, item) => {
+    if (!acc.includes(item.year)) {
+      acc.push(item.year)
+    }
+    return acc
+  }, [])
+const handleAdd = () => {
     addFormInput(formProjects, setProjects, maximumEntries, emptyFormData)
     setProjectsListSelection([...projectListSelection, { projects: [] }])
     setClientsFilter([...clientsFilter, { clients: [] }])
     setProjectsList([...projectList, { projects: [] }])
     setBusinessDivisionFilter([...businessDivisionFilter, { divisions: [] }])
+    setFilteredMonth([...filteredMonth, { month: [] }])
   }
 
   const handleMinus = () => {
@@ -169,8 +183,21 @@ const ProjectSalesResultsRegistration = () => {
       return prevFormProjects.map((form, i) => {
         if (i === index) {
           const resetFields = {
+            year: ['month', 'project_name', 'client', 'business_division'],
             month: ['project_name', 'client', 'business_division'],
             project_name: ['client', 'business_division'],
+          }
+          let month = form.month
+          if (name == 'year' && value == '') {
+            form.month = ''
+            setFilteredMonth((prev) => {
+              return prev.map((eachMonth, monthIndex) => {
+                if (index == monthIndex) {
+                  return [{}]
+                }
+                return eachMonth
+              })
+            })
           }
           const fieldsToReset = resetFields[name] || []
           const resetValues = fieldsToReset.reduce((acc, field) => {
@@ -199,6 +226,23 @@ const ProjectSalesResultsRegistration = () => {
           ...(month !== null && { month }),
           ...(year !== null && { year }),
           ...(projectId !== null && { projectId }),
+        }
+        if (filterParams.year) {
+          getFilteredProjectSalesResults(filterParams, token)
+            .then((data) => {
+              const uniqueData = data.filter(
+                (item, index, self) =>
+                  index === self.findIndex((t) => t.month === item.month)
+              );
+              setFilteredMonth((prev) => {
+                return prev.map((month, monthIndex) => {
+                  if (index == monthIndex) {
+                    return { month: uniqueData }
+                  }
+                  return month
+                })
+              })
+            })
         }
         if (filterParams.year && filterParams.month && filterParams.projectId) {
           getFilteredProjectSalesResults(filterParams, token)
@@ -305,6 +349,14 @@ const ProjectSalesResultsRegistration = () => {
         }
       }
     })
+    getProject(token)
+      .then((data) => {
+        console.table(data);
+        setProjectYear(data)
+      })
+      .catch((error) => {
+        console.log(' error fetching project sales results data: ' + error)
+      })
   }, [formProjects])
 
   const HandleClientChange = (e) => {
@@ -613,7 +665,7 @@ const ProjectSalesResultsRegistration = () => {
                             onChange={(e) => handleChange(index, e)}
                           >
                             <option value=''>{translate('selectYear', language)}</option>
-                            {years.map((year, idx) => (
+                            {uniqueYears.map((year, idx) => (
                               <option key={idx} value={year}>
                                 {year}
                               </option>
@@ -704,9 +756,9 @@ const ProjectSalesResultsRegistration = () => {
                             onChange={(e) => handleChange(index, e)}
                           >
                             <option value=''>{translate('selectMonth', language)}</option>
-                            {months.map((month, idx) => (
-                              <option key={idx} value={month}>
-                                {language === 'en' ? monthNames[month].en : monthNames[month].jp}
+                            {sortByFinancialYear(filteredMonth[index]?.month || []).map((month, idx) => (
+                              <option key={idx} value={month.month}>
+                                {language === 'en' ? monthNames[month.month].en : monthNames[month.month].jp}
                               </option>
                             ))}
                           </select>

--- a/client/src/pages/ProjectSalesResults/ProjectSalesResultsRegistration.tsx
+++ b/client/src/pages/ProjectSalesResults/ProjectSalesResultsRegistration.tsx
@@ -77,7 +77,7 @@ const ProjectSalesResultsRegistration = () => {
   const [businessSelection, setBusinessSelection] = useState<any>([])
   const [businessDivisionFilter, setBusinessDivisionFilter] = useState<Divisions[]>([{ divisions: [] }])
   const [filteredMonth, setFilteredMonth] = useState<any>([{ month: [] }])
-  const [ProjectYear, setProjectYear] = useState<any>([])
+  const [projectYear, setProjectYear] = useState<any>([])
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const [projectDataResult, setProjectDataResult] = useState<any>([])
   const [projectList, setProjectsList] = useState<Projects[]>([{ projects: [] }])
@@ -112,7 +112,7 @@ const ProjectSalesResultsRegistration = () => {
   }
 
   const [formProjects, setProjects] = useState([emptyFormData])
-  const uniqueYears = ProjectYear.reduce((acc, item) => {
+  const uniqueYears = projectYear.reduce((acc, item) => {
     if (!acc.includes(item.year)) {
       acc.push(item.year)
     }

--- a/client/src/pages/Projects/ProjectsListAndEdit.tsx
+++ b/client/src/pages/Projects/ProjectsListAndEdit.tsx
@@ -28,6 +28,7 @@ import { deleteProject } from '../../api/ProjectsEndpoint/DeleteProject'
 import { months, token, years } from '../../constants'
 import {
   handleDisableKeysOnNumberInputs,
+  removeCommas,
   formatNumberWithCommas,
   handleInputChange,
   handlePLListTabsClick,
@@ -98,6 +99,17 @@ const ProjectsListAndEdit: React.FC = ({}) => {
   }
 
   const handleClick = () => {
+    const updatedProjects = projects.map((project) => {
+      const selectedYear = parseInt(project.year, 10);
+      const monthsForProject = getMonthsByFiscalYear(selectedYear, currentFiscalYear);
+      return {
+        ...project,
+        months: monthsForProject,
+      };
+    });
+    
+    setProjects(updatedProjects);
+
     setIsEditing((prevState) => !prevState)
   }
   useEffect(() => {
@@ -111,11 +123,44 @@ const ProjectsListAndEdit: React.FC = ({}) => {
     }
   }, [isEditing])
 
+  const currentDate = new Date()
+  const currentYear = currentDate.getFullYear()
+  const currentFiscalYear = currentDate.getMonth() + 1 < 4 ? currentYear - 1 : currentYear
+  const [months, setMonths] = useState<number[]>([])
+
   const handleChange = (index, event) => {
     const nonFinancialFieldsArray = ['year', 'month', 'project_name', 'project_type', 'client', 'business_division']
     handleInputChange(index, event, setProjects, projects, nonFinancialFieldsArray)
-  }
 
+    const { name, value } = event.target
+
+    // Remove commas to get the raw number
+    // EG. 999,999 → 999999 in the DB
+    const rawValue = removeCommas(value)
+
+    if (name === 'year') {
+      const selectedYear = parseInt(rawValue, 10)
+      const updatedProjects = [...projects];
+      const updatedMonths = getMonthsByFiscalYear(selectedYear, currentFiscalYear);
+      setMonths(updatedMonths);
+      updatedProjects[index] = {
+        ...updatedProjects[index],
+        year: value,
+        months: updatedMonths,
+        month: '',
+      };
+      setProjects(updatedProjects);
+    }
+  }
+  const getMonthsByFiscalYear = (selectedYear, currentFiscalYear) => {
+    if (selectedYear === currentFiscalYear) {
+      return [4, 5, 6, 7, 8, 9, 10, 11, 12];
+    } else if (selectedYear === currentFiscalYear + 1) {
+      return [1, 2, 3];
+    } else {
+      return [];
+    }
+  };
   const handleSubmit = async () => {
     setFormProjects(projects)
     // # Client Side Validation
@@ -475,7 +520,7 @@ const ProjectsListAndEdit: React.FC = ({}) => {
                                         onChange={(e) => handleChange(index, e)}
                                       >
                                         <option value=''></option>
-                                        {months.map((month, idx) => (
+                                        {project.months && project.months.map((month, idx) => (
                                           <option key={idx} value={month}>
                                             {month}月
                                           </option>


### PR DESCRIPTION
# Pull Request Review Comments

## Overview
- **Purpose of the PR**:
    - [ ] English
Project Sales Results Registration: Only year/months that exist in 'projects' should be available in drop-downs.
Projects Edit (planning) should have same dropdown logic as registration. 2024 (4-12) , 2025 (1-3).

日本語
案件実績登録： プロジェクト」に存在する年/月のみ、ドロップダウンで利用できるようにする。
案件編集(計画)は、登録と同じドロップダウンのロジックを持つべきである。2024 (4-12) , 2025 (1-3).